### PR TITLE
Sml generator edits

### DIFF
--- a/SimpleCompiler/Simple/SMLGenerator.h
+++ b/SimpleCompiler/Simple/SMLGenerator.h
@@ -55,6 +55,7 @@ private:
 	void terminate(const string&);
 	void postfixEval(string&);
 	void evaluateLetStatement (string&, int&, int&);
+	void evaluateIfGotoStatement (string&, int&, int&);
 };
 
 #endif

--- a/SimpleCompiler/Simple/SMLUtilities.cpp
+++ b/SimpleCompiler/Simple/SMLUtilities.cpp
@@ -5,14 +5,25 @@
 
 using namespace std;
 
+/*Could use isdigit, but this function handles the whole string rather than just one character*/
 bool SMLUtilities::IsIntConstant(string& str){
-	try{
-		int constant = stoi(str);
-		return true;
+	int strLength = str.length();
+	for (int i = 0; i < strLength; ++i){
+		if (!isdigit(str.at(i))){
+			return false;
+		}
 	}
-	catch(std::invalid_argument&){
-		return false;
+	return true;
+}
+
+bool SMLUtilities::IsStrAlpha(const string& str){
+	int strLength = str.length();
+	for (int i = 0; i < strLength; ++i){
+		if (!isalpha(str.at(i))){
+			return false;
+		}
 	}
+	return true;
 }
 
 void SMLUtilities::trim(string& str){

--- a/SimpleCompiler/Simple/SMLUtilities.h
+++ b/SimpleCompiler/Simple/SMLUtilities.h
@@ -6,12 +6,11 @@
 class SMLUtilities{
 public:
 	static bool IsIntConstant(std::string&);
+	static bool IsStrAlpha(const std::string&);
 	static void trim(std::string&);
 	static std::string addSpace(std::string&);
 	static bool isoperator (const char&, const bool&);
 	static void terminate(const std::string&);
 };
-
-
 
 #endif


### PR DESCRIPTION
Check that the variable names are alpha in Input & Print statements.
Check that the GOTO statement has a valid integer for the branch location.
Fix issue with the function SMLUtilities::IsIntConstant() not correctly confirming if the parameter is an integer.
Second pass uses the constant variable to avoid the sizeof() function for each iteration.
Second pass now detects incorrect branch locations.
Created new function evalIfGotoStatement().
